### PR TITLE
Adds red button for deployments skipping bintray

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,4 +129,31 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>sonatype</id>
+      <distributionManagement>
+        <repository>
+          <id>sonatype</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-release-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
our zipkin-api repo died.. we have to get bintray to restore it.

Meanwhile, this is instructions to release. Similar to https://github.com/openzipkin/zipkin-aws/pull/137

Ex from tag 2.12.10
```bash
$ SONATYPE_USER=adriancole SONATYPE_PASSWORD=letmein GPG_TTY=$(tty) ./mvnw -s .settings.xml -Prelease -Psonatype deploy -DskipTests
```

then I close and release repo from https://oss.sonatype.org/#stagingRepositories