### PR TITLE
Update the correct Zipkin logo URL

### DIFF
--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -1,6 +1,6 @@
   <nav id='navbar' class='navbar navbar-expand-lg navbar-dark bg-dark'>
           <a class='navbar-brand ml-5' href='{{contextRoot}}'>
-          <img src="https://zipkin.io/public/img/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
+          <img src="https://zipkin.io/public/img/old logo/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
             <span class='font-weight-light navbar-text' style="font-size: .75em;" data-i18n="nav.inves">Investigate system behavior</span>
           </a>
         <div class="collapse navbar-collapse">


### PR DESCRIPTION
I'd like to update the correct Zipkin logo URL because the old Zipkin logo was moved and broke Zipkin UI layout.