### PR TITLE
Change top logo's image path

### DIFF
--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -1,6 +1,6 @@
   <nav id='navbar' class='navbar navbar-expand-lg navbar-dark bg-dark'>
           <a class='navbar-brand ml-5' href='{{contextRoot}}'>
-          <img src="https://zipkin.io/public/img/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
+          <img src="https://zipkin.io/public/img/old%20logo/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
             <span class='font-weight-light navbar-text' style="font-size: .75em;" data-i18n="nav.inves">Investigate system behavior</span>
           </a>
         <div class="collapse navbar-collapse">


### PR DESCRIPTION
in this PR https://github.com/openzipkin/openzipkin.github.io/pull/142, old logo's path is changed.
due to this, https://github.com/openzipkin/zipkin/issues/2961 occurred.
So we need to update logo's image path of zipkin-classic too.