### PR TITLE
Changes to zipkin-classic package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ cache:
 
 language: java
 
-jdk:
-  - oraclejdk8
+jdk: openjdk11
 
 before_install:
   # parameters used during a release
@@ -26,13 +25,9 @@ before_install:
   - git config credential.helper "store --file=.git/credentials"
   - echo "https://$GH_TOKEN:@github.com" > .git/credentials
 
-install:
-  # Override default travis to use the maven wrapper
-  # skip license on travis due to #1512
-  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dlicense.skip=true
-
-script:
-  - ./travis/publish.sh
+# Override default travis to use the maven wrapper; skip license on travis due to #1512
+install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V
+script: ./travis/publish.sh
 
 # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
 # See https://github.com/travis-ci/travis-ci/issues/1532

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version>2.19.2</version>
   </parent>
 
-  <groupId>io.zipkin.java</groupId>
+  <groupId>io.zipkin.classic</groupId>
   <artifactId>zipkin-ui</artifactId>
   <version>2.12.12-SNAPSHOT</version>
   <name>Zipkin UI</name>
@@ -38,6 +38,39 @@
     </developerConnection>
     <tag>HEAD</tag>
   </scm>
+
+  <organization>
+    <name>OpenZipkin</name>
+    <url>http://zipkin.io/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <!-- Developer section is needed for Maven Central, but doesn't need to include each person -->
+  <developers>
+    <developer>
+      <id>openzipkin</id>
+      <name>OpenZipkin Gitter</name>
+      <url>https://gitter.im/openzipkin/zipkin</url>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/zipkin-classic/;publish=1</url>
+    </repository>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <issueManagement>
     <system>Github</system>
@@ -133,6 +166,14 @@
             <phase>none</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
+        <artifactId>centralsync-maven-plugin</artifactId>
+        <version>0.1.1</version>
+        <configuration>
+          <packageName>zipkin-classic</packageName>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Before, our publishing wouldn't work due to overlap with the old zipkin package.